### PR TITLE
Adding analytics API service

### DIFF
--- a/uber_analytics/__init__.py
+++ b/uber_analytics/__init__.py
@@ -1,6 +1,8 @@
 from uber.common import *
 from uber_analytics._version import __version__
 
+from uber_analytics import api
+
 config = parse_config(__file__)
 mount_site_sections(config['module_root'])
 static_overrides(join(config['module_root'], 'static'))

--- a/uber_analytics/api.py
+++ b/uber_analytics/api.py
@@ -1,0 +1,24 @@
+from uber.common import *
+
+from .site_sections.graphs import RegistrationDataOneYear
+
+class AnalyticsApi:
+    def badge_sale_history(self):
+        with Session() as session:
+            reg_data = RegistrationDataOneYear()
+            reg_data.query_current_year(session)
+
+            return {
+                'current_registrations': reg_data.dump_data(),
+            }
+
+    def badge_stats(self):
+        return {
+            'badges_sold': c.BADGES_SOLD,
+            'remaining_badges': c.REMAINING_BADGES,
+            'badges_price': c.BADGE_PRICE,
+            'server_current_timestamp': int(datetime.utcnow().timestamp()),
+            'warn_if_server_browser_time_mismatch': c.WARN_IF_SERVER_BROWSER_TIME_MISMATCH
+        }
+
+services.register(AnalyticsApi(),'analytics')


### PR DESCRIPTION
This change isn't the ideal way to solve this problem.  Ideally we'd be defining the services as the foundation of the uber_analytics plugin and building the graph and frontend around those services. 

This way of doing things does as little as possible to change existing code to make it easier to backport this change to older instances of uber to be able to pull historical stats.