### PR TITLE
Remove base-admin.html

### DIFF
--- a/uber_analytics/templates/graphs/index.html
+++ b/uber_analytics/templates/graphs/index.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Attendance Graphs{% endblock %}
 {% block head_javascript %}
     {{ super() }}


### PR DESCRIPTION
Now that we have Jinja2 templating, we can use the variable admin_area to control what gets included in child templates, rather than inheriting from a different template. We're implementing that now.